### PR TITLE
[Feat] 피그마 디자인 시스템 전역 CSS 추가

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,26 +1,230 @@
 @import 'tailwindcss';
 
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
+@theme {
+  /* 기본 배경/전경색 */
+  --color-background: #ffffff;
+  --color-foreground: #171717;
+
+  /* Primary & Error Colors */
+  --color-pri: #5534da;
+  --color-err: #d6173a;
+
+  /* Dashboard Colors */
+  --color-db-green: #7ac555;
+  --color-db-orange: #ffa500;
+  --color-db-blue: #76a5ea;
+  --color-db-pink: #e876ea;
+  --color-db-purple: #760dde;
+
+  /* Black 계열 */
+  --color-black: #000000;
+  --color-black-100: #171717;
+  --color-black-200: #333236;
+  --color-black-300: #4b4b4b;
+
+  /* Gray 계열 */
+  --color-gray-100: #787486;
+  --color-gray-200: #9fa6b2;
+  --color-gray-300: #d9d9d9;
+  --color-gray-400: #eeeeee;
+  --color-gray-500: #fafafa;
+
+  /* White */
+  --color-white: #ffffff;
+
+  /* Secondary Colors */
+  --color-sec-black: #333236;
+  --color-sec-white-50: #ffffff;
+  --color-sec-white-100: #fafafa;
+  --color-sec-gray-100: #d9d9d9;
+  --color-sec-gray-200: #9fa6b2;
+  --color-sec-gray-300: #787486;
+
+  /* Background */
+  --color-pri-bg-soft: #f1effd;
+
+  /* Font Family */
+  --font-sans: 'Pretendard', Arial, Helvetica, sans-serif;
 }
 
-@theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+/* 피그마 폰트 스타일 - Tailwind 4.1 방식 */
+@utility text-3xl-bold {
+  font-size: 32px;
+  line-height: 42px;
+  font-weight: 700;
 }
 
-/* @media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
+@utility text-3xl-semibold {
+  font-size: 32px;
+  line-height: 42px;
+  font-weight: 600;
+}
+
+@utility text-2xl-bold {
+  font-size: 24px;
+  line-height: 32px;
+  font-weight: 700;
+}
+
+@utility text-2xl-semibold {
+  font-size: 24px;
+  line-height: 32px;
+  font-weight: 600;
+}
+
+@utility text-2xl-medium {
+  font-size: 24px;
+  line-height: 32px;
+  font-weight: 500;
+}
+
+@utility text-2xl-regular {
+  font-size: 24px;
+  line-height: 32px;
+  font-weight: 400;
+}
+
+@utility text-xl-bold {
+  font-size: 20px;
+  line-height: 32px;
+  font-weight: 700;
+}
+
+@utility text-xl-semibold {
+  font-size: 20px;
+  line-height: 32px;
+  font-weight: 600;
+}
+
+@utility text-xl-medium {
+  font-size: 20px;
+  line-height: 32px;
+  font-weight: 500;
+}
+
+@utility text-xl-regular {
+  font-size: 20px;
+  line-height: 32px;
+  font-weight: 400;
+}
+
+@utility text-2lg-bold {
+  font-size: 18px;
+  line-height: 26px;
+  font-weight: 700;
+}
+
+@utility text-2lg-semibold {
+  font-size: 18px;
+  line-height: 26px;
+  font-weight: 600;
+}
+
+@utility text-2lg-medium {
+  font-size: 18px;
+  line-height: 26px;
+  font-weight: 500;
+}
+
+@utility text-2lg-regular {
+  font-size: 18px;
+  line-height: 26px;
+  font-weight: 400;
+}
+
+@utility text-lg-bold {
+  font-size: 16px;
+  line-height: 26px;
+  font-weight: 700;
+}
+
+@utility text-lg-semibold {
+  font-size: 16px;
+  line-height: 26px;
+  font-weight: 600;
+}
+
+@utility text-lg-medium {
+  font-size: 16px;
+  line-height: 26px;
+  font-weight: 500;
+}
+
+@utility text-lg-regular {
+  font-size: 16px;
+  line-height: 26px;
+  font-weight: 400;
+}
+
+@utility text-md-bold {
+  font-size: 14px;
+  line-height: 24px;
+  font-weight: 700;
+}
+
+@utility text-md-semibold {
+  font-size: 14px;
+  line-height: 24px;
+  font-weight: 600;
+}
+
+@utility text-md-medium {
+  font-size: 14px;
+  line-height: 24px;
+  font-weight: 500;
+}
+
+@utility text-md-regular {
+  font-size: 14px;
+  line-height: 24px;
+  font-weight: 400;
+}
+
+@utility text-sm-semibold {
+  font-size: 13px;
+  line-height: 22px;
+  font-weight: 600;
+}
+
+@utility text-sm-medium {
+  font-size: 13px;
+  line-height: 22px;
+  font-weight: 500;
+}
+
+@utility text-xs-semibold {
+  font-size: 12px;
+  line-height: 20px;
+  font-weight: 600;
+}
+
+@utility text-xs-medium-20 {
+  font-size: 12px;
+  line-height: 20px;
+  font-weight: 500;
+}
+
+@utility text-xs-medium-18 {
+  font-size: 12px;
+  line-height: 18px;
+  font-weight: 500;
+}
+
+@utility text-xs-regular {
+  font-size: 12px;
+  line-height: 18px;
+  font-weight: 400;
+}
+
+@supports (-webkit-touch-callout: none) {
+  /* 아이폰에서 vh값 구하기 */
+  .h-screen {
+    height: -webkit-fill-available;
   }
-} */
+}
 
 body {
-  background: var(--background);
-  color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  background: var(--color-background);
+  color: var(--color-foreground);
+  font-family: var(--font-sans);
 }


### PR DESCRIPTION
##  작업 내용
- 피그마 컬러 시스템을 Tailwind 4.1 방식으로 추가
- 커스텀 폰트 스타일 유틸리티 클래스 정의  
- 의미 기반 색상 네이밍 적용

## 기능
- Primary/Error 색상: `text-pri`, `bg-err`
- 대시보드 색상: `fill-db-green`, `bg-db-orange` 등
- 피그마 폰트 스타일: `text-3xl-bold`, `text-md-regular` 등

##  사용 예시
```tsx
<span className="text-pri">텍스트 pri 컬러</span>
<div className="bg-db-green">대시보드 색상</div>
<h1 className="text-3xl-bold">제목</h1>
```

ps. 새론님이 중간에 도와주셨습니다 감사해요!