### PR TITLE
[Feat/LandingPage] 랜딩페이지 테블릿 해상도버전 추가

### DIFF
--- a/src/app/landing/page.tsx
+++ b/src/app/landing/page.tsx
@@ -42,8 +42,8 @@ const LandingPage = () => {
         <div className='max-w-7xl mx-auto px-4 text-center'>
           {/* Main Image */}
           <div className='flex justify-center mb-6 md:mb-8 lg:mb-12'>
-            {/* Mobile - No background */}
-            <div className='md:hidden'>
+            {/* Mobile (375-743) - No background */}
+            <div className='block md:hidden'>
               <Image
                 src='/images/desktop.png'
                 alt='Taskify 팀 협업 일러스트'
@@ -53,8 +53,20 @@ const LandingPage = () => {
                 priority
               />
             </div>
-            {/* Desktop - No background, fixed size */}
-            <div className='hidden md:block'>
+            {/* Tablet (744-1023) - No background */}
+            <div className='hidden md:block lg:hidden'>
+              <Image
+                src='/images/desktop.png'
+                alt='Taskify 팀 협업 일러스트'
+                width={538}
+                height={315}
+                className='max-w-none'
+                priority
+                style={{ width: '538px', height: '315px' }}
+              />
+            </div>
+            {/* PC (1024+) - No background, fixed size */}
+            <div className='hidden lg:block'>
               <Image
                 src='/images/desktop.png'
                 alt='Taskify 팀 협업 일러스트'
@@ -69,17 +81,32 @@ const LandingPage = () => {
           {/* Title - Mobile First - Semantic Structure */}
           <section className='mb-6 md:mb-8'>
             {/* 새로운 일정 관리 */}
-            <h1
-              className='font-bold text-white mb-2 md:mb-0 md:inline-block'
-              style={{
-                fontSize: '40px',
-                fontWeight: 700,
-                fontFamily: 'Pretendard',
-              }}
-            >
-              <span className='md:hidden'>새로운 일정 관리</span>
+            <h1 className='font-bold text-white mb-2 md:mb-0 md:inline-block lg:inline-block'>
+              {/* Mobile (375-743) */}
               <span
-                className='hidden md:inline'
+                className='block md:hidden'
+                style={{
+                  fontSize: '40px',
+                  fontWeight: 700,
+                  fontFamily: 'Pretendard',
+                }}
+              >
+                새로운 일정 관리
+              </span>
+              {/* Tablet (744-1023) */}
+              <span
+                className='hidden md:inline lg:hidden'
+                style={{
+                  fontSize: '56px',
+                  fontWeight: 700,
+                  fontFamily: 'Pretendard',
+                }}
+              >
+                새로운 일정 관리{' '}
+              </span>
+              {/* PC (1024+) */}
+              <span
+                className='hidden lg:inline'
                 style={{
                   fontSize: '76px',
                   fontWeight: 700,
@@ -91,19 +118,35 @@ const LandingPage = () => {
             </h1>
 
             {/* Taskify */}
-            <h2
-              className='font-bold text-[#5534DA] md:inline-block md:leading-[65px]'
-              style={{
-                fontSize: '42px',
-                fontWeight: 700,
-                fontFamily: 'Montserrat',
-              }}
-            >
-              <span className='md:hidden'>Taskify</span>
+            <h2 className='font-bold text-[#5534DA] md:inline-block lg:inline-block lg:leading-[65px]'>
+              {/* Mobile (375-743) */}
               <span
-                className='hidden md:inline'
+                className='block md:hidden'
                 style={{
-                  fontSize: '90px',
+                  fontSize: '42px',
+                  fontWeight: 700,
+                  fontFamily: 'Montserrat',
+                }}
+              >
+                Taskify
+              </span>
+              {/* Tablet (744-1023) */}
+              <span
+                className='hidden md:inline lg:hidden'
+                style={{
+                  fontSize: '70px',
+                  fontWeight: 700,
+                  fontFamily: 'Montserrat',
+                  letterSpacing: '-1px',
+                }}
+              >
+                Taskify
+              </span>
+              {/* PC (1024+) */}
+              <span
+                className='hidden lg:inline'
+                style={{
+                  fontSize: '83px',
                   fontWeight: 700,
                   fontFamily: 'Montserrat',
                   letterSpacing: '-1px',
@@ -134,18 +177,18 @@ const LandingPage = () => {
 
       {/* Point 1 Section - Mobile First */}
       <section className='bg-black py-8 md:py-12 lg:py-20'>
-        <div className='max-w-7xl mx-auto px-4'>
-          <div className='bg-[#171717] rounded-lg mx-auto relative overflow-hidden w-full max-w-sm h-[600px] md:max-w-none md:w-full md:h-[600px] lg:w-[1200px] lg:h-[600px]'>
-            {/* Mobile Layout - Stacked */}
-            <div className='md:hidden p-6 text-center h-full flex flex-col relative'>
+        <div className='max-w-7xl mx-auto px-4 md:px-10'>
+          <div className='bg-[#171717] rounded-lg mx-auto relative overflow-hidden w-full max-w-sm h-[600px] md:w-[664px] md:h-[972px] md:max-w-none lg:max-w-none lg:w-full lg:h-[600px] xl:w-[1200px] xl:h-[600px]'>
+            {/* Mobile & Tablet Layout - Stacked */}
+            <div className='lg:hidden p-6 text-center md:text-left h-full flex flex-col relative'>
               <div
-                className='text-[#5534DA] text-sm font-medium mb-6 mt-8'
+                className='text-[#5534DA] text-sm font-medium mb-6 md:mb-[100px] mt-8 md:mt-12 md:ml-8'
                 style={{ fontSize: '18px', fontWeight: 500, fontFamily: 'Pretendard' }}
               >
                 Point 1
               </div>
               <h2
-                className='text-4xl font-bold text-white leading-tight mb-12'
+                className='text-4xl font-bold text-white leading-tight mb-12 md:ml-8 md:mb-0'
                 style={{ fontWeight: 700 }}
               >
                 일의 우선순위를
@@ -154,7 +197,8 @@ const LandingPage = () => {
               </h2>
               {/* Point 1 이미지를 컨테이너 우측 하단에 절대 위치 */}
               <div className='absolute bottom-0 right-0'>
-                <div style={{ width: '296px', height: '248px' }}>
+                {/* Mobile 이미지 */}
+                <div className='md:hidden' style={{ width: '296px', height: '248px' }}>
                   <Image
                     src='/images/landing1.svg'
                     alt='칸반 보드 대시보드'
@@ -164,11 +208,25 @@ const LandingPage = () => {
                     style={{ width: '296px', height: '248px' }}
                   />
                 </div>
+                {/* Tablet 이미지 */}
+                <div
+                  className='hidden md:block lg:hidden'
+                  style={{ width: '520px', height: '435px' }}
+                >
+                  <Image
+                    src='/images/landing1.svg'
+                    alt='칸반 보드 대시보드'
+                    width={520}
+                    height={435}
+                    className='rounded-lg w-full h-full object-contain'
+                    style={{ width: '520px', height: '435px' }}
+                  />
+                </div>
               </div>
             </div>
 
-            {/* Desktop Layout - Side by side */}
-            <div className='hidden md:flex items-center h-full p-8 lg:p-12'>
+            {/* PC Layout - Side by side */}
+            <div className='hidden lg:flex items-center h-full p-8 xl:p-12'>
               {/* Text Content - Left */}
               <div className='flex flex-col justify-center w-1/2'>
                 <div
@@ -181,14 +239,14 @@ const LandingPage = () => {
                   className='font-bold mb-6 text-white'
                   style={{ fontSize: '48px', fontWeight: 700 }}
                 >
-                  일의 <span className='text-[#5534DA]'>우선순위</span>를<br />
+                  일의 <span className='text-pri'>우선순위</span>를<br />
                   관리하세요
                 </h2>
               </div>
             </div>
 
-            {/* Dashboard Image - Desktop positioning */}
-            <div className='hidden md:block absolute bottom-0 right-0'>
+            {/* Dashboard Image - PC positioning */}
+            <div className='hidden lg:block absolute bottom-0 right-0'>
               <Image
                 src='/images/landing1.svg'
                 alt='칸반 보드 대시보드'
@@ -203,18 +261,18 @@ const LandingPage = () => {
 
       {/* Point 2 Section - Mobile First */}
       <section className='bg-black py-8 md:py-12 lg:py-20'>
-        <div className='max-w-7xl mx-auto px-4'>
-          <div className='bg-[#171717] rounded-lg mx-auto relative overflow-hidden w-full max-w-sm h-[600px] md:max-w-none md:w-full md:h-[600px] lg:w-[1200px] lg:h-[600px]'>
-            {/* Mobile Layout - Stacked */}
-            <div className='md:hidden p-6 text-center h-full flex flex-col relative'>
+        <div className='max-w-7xl mx-auto px-4 md:px-10'>
+          <div className='bg-[#171717] rounded-lg mx-auto relative overflow-hidden w-full max-w-sm h-[600px] md:w-[664px] md:h-[972px] md:max-w-none lg:max-w-none lg:w-full lg:h-[600px] xl:w-[1200px] xl:h-[600px]'>
+            {/* Mobile & Tablet Layout - Stacked */}
+            <div className='lg:hidden p-6 text-center md:text-left h-full flex flex-col relative'>
               <div
-                className='text-[#5534DA] text-sm font-medium mb-6 mt-8'
+                className='text-[#5534DA] text-sm font-medium mb-6 md:mb-[100px] mt-8 md:mt-12 md:ml-8'
                 style={{ fontSize: '18px', fontWeight: 500, fontFamily: 'Pretendard' }}
               >
                 Point 2
               </div>
               <h2
-                className='text-4xl font-bold text-white leading-tight mb-12'
+                className='text-4xl font-bold text-white leading-tight mb-12 md:ml-8 md:mb-0'
                 style={{ fontWeight: 700 }}
               >
                 해야 할 일을
@@ -223,7 +281,8 @@ const LandingPage = () => {
               </h2>
               {/* Point 2 이미지를 컨테이너 하단 중앙에 절대 위치 */}
               <div className='absolute bottom-0 left-1/2 transform -translate-x-1/2'>
-                <div style={{ width: '218px', height: '250px' }}>
+                {/* Mobile 이미지 */}
+                <div className='md:hidden' style={{ width: '218px', height: '250px' }}>
                   <Image
                     src='/images/landing2.svg'
                     alt='할일 생성 폼'
@@ -233,13 +292,27 @@ const LandingPage = () => {
                     style={{ width: '218px', height: '250px' }}
                   />
                 </div>
+                {/* Tablet 이미지 */}
+                <div
+                  className='hidden md:block lg:hidden'
+                  style={{ width: '361px', height: '415px' }}
+                >
+                  <Image
+                    src='/images/landing2.svg'
+                    alt='할일 생성 폼'
+                    width={361}
+                    height={415}
+                    className='rounded-lg w-full h-full object-contain'
+                    style={{ width: '361px', height: '415px' }}
+                  />
+                </div>
               </div>
             </div>
 
-            {/* Desktop Layout - Side by side */}
-            <div className='hidden md:flex items-center h-full p-8 lg:p-12'>
+            {/* PC Layout - Side by side */}
+            <div className='hidden lg:flex items-center h-full p-8 xl:p-12'>
               {/* Text Content - Right */}
-              <div className='flex flex-col justify-center w-1/2 ml-auto'>
+              <div className='flex flex-col justify-center w-2/5 ml-auto mr-8'>
                 <div
                   className='text-[#5534DA] font-medium mb-4'
                   style={{ fontSize: '22px', fontWeight: 500 }}
@@ -257,8 +330,8 @@ const LandingPage = () => {
               </div>
             </div>
 
-            {/* Task Form Image - Desktop positioning */}
-            <div className='hidden md:block absolute bottom-0 left-27'>
+            {/* Task Form Image - PC positioning */}
+            <div className='hidden lg:block absolute bottom-0 left-27'>
               <Image
                 src='/images/landing2.svg'
                 alt='할일 생성 폼'
@@ -275,21 +348,21 @@ const LandingPage = () => {
       <section className='bg-black py-8 md:py-12 lg:py-20'>
         <div className='max-w-7xl mx-auto px-4'>
           {/* Section Title */}
-          <div className='text-center md:text-left mb-8 md:mb-12 lg:mb-16'>
+          <div className='text-center lg:text-left mb-8 md:mb-12 lg:mb-16'>
             <h2 className='text-xl md:text-3xl lg:text-4xl font-bold text-white'>
               생산성을 높이는 다양한 설정 <span className='text-[#5534DA]'>⚡</span>
             </h2>
           </div>
 
-          {/* Settings Grid - Mobile First: Single column, Desktop: 3 columns */}
-          <div className='space-y-4 md:space-y-0 md:grid md:grid-cols-2 lg:grid-cols-3 md:gap-6 lg:gap-8'>
+          {/* Settings Grid - Mobile & Tablet: Single column, PC: 3 columns */}
+          <div className='space-y-4 lg:space-y-0 lg:grid lg:grid-cols-3 lg:gap-8'>
             {/* Dashboard Setting */}
             <div
-              className='bg-[#5C5C5C] rounded-lg overflow-hidden flex flex-col mx-auto w-full md:max-w-none md:w-full lg:w-[378px] lg:h-[384px]'
+              className='bg-[#5C5C5C] rounded-lg overflow-hidden flex flex-col mx-auto w-full lg:w-[378px] lg:h-[384px]'
               style={{ width: '343px', maxWidth: '343px' }}
             >
               <div
-                className='bg-[#4B4B4B] flex items-center justify-center md:flex-1 md:p-6'
+                className='bg-[#4B4B4B] flex items-center justify-center lg:flex-1 lg:p-6'
                 style={{ height: '236px' }}
               >
                 <Image
@@ -297,22 +370,22 @@ const LandingPage = () => {
                   alt='대시보드 설정 UI'
                   width={320}
                   height={132}
-                  className='md:w-[300px] md:h-[124px]'
+                  className='lg:w-[300px] lg:h-[124px]'
                 />
               </div>
               <div
-                className='bg-[#171717] flex items-center md:p-6'
+                className='bg-[#171717] flex items-center lg:p-6'
                 style={{ height: '113px', padding: '24px' }}
               >
                 <div>
                   <h3
-                    className='font-bold mb-2 md:mb-3 text-white md:text-xl'
+                    className='font-bold mb-2 lg:mb-3 text-white lg:text-xl'
                     style={{ fontSize: '18px', fontWeight: 700 }}
                   >
                     대시보드 설정
                   </h3>
                   <p
-                    className='text-gray-400 md:text-sm'
+                    className='text-gray-400 lg:text-sm'
                     style={{ fontSize: '16px', fontWeight: 500 }}
                   >
                     대시보드 사진과 이름을 변경할 수 있어요.
@@ -323,11 +396,11 @@ const LandingPage = () => {
 
             {/* Invitation */}
             <div
-              className='bg-[#5C5C5C] rounded-lg overflow-hidden flex flex-col mx-auto w-full md:max-w-none md:w-full lg:w-[378px] lg:h-[384px]'
+              className='bg-[#5C5C5C] rounded-lg overflow-hidden flex flex-col mx-auto w-full lg:w-[378px] lg:h-[384px]'
               style={{ width: '343px', maxWidth: '343px' }}
             >
               <div
-                className='bg-[#4B4B4B] flex items-center justify-center md:flex-1 md:p-1'
+                className='bg-[#4B4B4B] flex items-center justify-center lg:flex-1 lg:p-1'
                 style={{ height: '236px' }}
               >
                 <Image
@@ -335,22 +408,22 @@ const LandingPage = () => {
                   alt='초대 관리 UI'
                   width={260}
                   height={200}
-                  className='md:w-[300px] md:h-[220px]'
+                  className='lg:w-[300px] lg:h-[220px]'
                 />
               </div>
               <div
-                className='bg-[#171717] flex items-center md:p-6'
+                className='bg-[#171717] flex items-center lg:p-6'
                 style={{ height: '113px', padding: '24px' }}
               >
                 <div>
                   <h3
-                    className='font-bold mb-2 md:mb-3 text-white md:text-xl'
+                    className='font-bold mb-2 lg:mb-3 text-white lg:text-xl'
                     style={{ fontSize: '18px', fontWeight: 700 }}
                   >
                     초대
                   </h3>
                   <p
-                    className='text-gray-400 md:text-sm'
+                    className='text-gray-400 lg:text-sm'
                     style={{ fontSize: '16px', fontWeight: 500 }}
                   >
                     새로운 팀원을 초대할 수 있어요.
@@ -361,11 +434,11 @@ const LandingPage = () => {
 
             {/* Members */}
             <div
-              className='bg-[#5C5C5C] rounded-lg overflow-hidden flex flex-col mx-auto w-full md:max-w-none md:w-full md:col-span-2 lg:col-span-1 lg:w-[378px] lg:h-[384px]'
+              className='bg-[#5C5C5C] rounded-lg overflow-hidden flex flex-col mx-auto w-full lg:w-[378px] lg:h-[384px]'
               style={{ width: '343px', maxWidth: '343px' }}
             >
               <div
-                className='bg-[#4B4B4B] flex items-center justify-center md:flex-1 md:p-6'
+                className='bg-[#4B4B4B] flex items-center justify-center lg:flex-1 lg:p-6'
                 style={{ height: '236px' }}
               >
                 <Image
@@ -373,23 +446,23 @@ const LandingPage = () => {
                   alt='구성원 관리 UI'
                   width={260}
                   height={169}
-                  className='md:w-[320px] md:h-[220px]'
+                  className='lg:w-[320px] lg:h-[220px]'
                   style={{ width: '260px', height: '169px' }}
                 />
               </div>
               <div
-                className='bg-[#171717] flex items-center md:p-6'
+                className='bg-[#171717] flex items-center lg:p-6'
                 style={{ height: '113px', padding: '24px' }}
               >
                 <div>
                   <h3
-                    className='font-bold mb-2 md:mb-3 text-white md:text-xl'
+                    className='font-bold mb-2 lg:mb-3 text-white lg:text-xl'
                     style={{ fontSize: '18px', fontWeight: 700 }}
                   >
                     구성원
                   </h3>
                   <p
-                    className='text-gray-400 md:text-sm'
+                    className='text-gray-400 lg:text-sm'
                     style={{ fontSize: '16px', fontWeight: 500 }}
                   >
                     구성원을 초대하고 내보낼 수 있어요.
@@ -405,7 +478,7 @@ const LandingPage = () => {
       <footer className='bg-black py-6 md:py-8'>
         <div className='max-w-7xl mx-auto px-4'>
           {/* Mobile Layout - Stacked */}
-          <div className='md:hidden text-center space-y-4'>
+          <div className='block md:hidden text-center space-y-4'>
             <div className='text-gray-400 text-sm'>©codeit - 2023</div>
             <div className='flex justify-center space-x-6'>
               <Link href='' className='text-gray-400 hover:text-white text-sm'>
@@ -428,13 +501,13 @@ const LandingPage = () => {
               </Link>
               <Link href='' className='text-gray-400 hover:text-white'>
                 <svg className='w-5 h-5' fill='currentColor' viewBox='0 0 24 24'>
-                  <path d='M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.40z' />
+                  <path d='M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.40z' />
                 </svg>
               </Link>
             </div>
           </div>
 
-          {/* Desktop Layout - Horizontal */}
+          {/* Tablet & PC Layout - Horizontal */}
           <div className='hidden md:flex justify-between items-center'>
             <div className='text-gray-400 text-sm'>©codeit - 2023</div>
             <div className='flex space-x-6'>
@@ -458,7 +531,7 @@ const LandingPage = () => {
               </Link>
               <Link href='' className='text-gray-400 hover:text-white'>
                 <svg className='w-5 h-5' fill='currentColor' viewBox='0 0 24 24'>
-                  <path d='M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.40z' />
+                  <path d='M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.40z' />
                 </svg>
               </Link>
             </div>


### PR DESCRIPTION
## ✨ 작업 내용

<!-- 어떤 작업을 했는지 간단히 작성해주세요 -->

1. 랜딩페이지 리팩토링 및 로그인,회원가입 페이지로 이동할수있게 수정하였습니다
2. 랜딩페이지 PC,테블릿,모바일 사이즈기준을 변경했습니다 Mobile(375-743), Tablet(744-1023), PC(1024+)
3. 랜딩페이지 테블릿사이즈 (744-1023) 추가했습니다 

<details>
<Summary>Tablet</Summary>
<img width="768" height="4278" alt="screencapture-localhost-3000-landing-2025-07-22-22_30_45" src="https://github.com/user-attachments/assets/cdad75a6-b7c4-4b04-9db1-6769dc51b534" />


</details>


사진은좀 이상하지만 vercel Preview로 해상도 744-1023 에서 보시면 깔끔하게나와요!

## 🔗 관련 이슈

<!-- 예: Fixes #1 (머지 시 이슈 자동 종료) -->