### PR TITLE
[Feat/dashboard edit] 대시보드 수정 페이지 1차 구현

### DIFF
--- a/src/app/dashboard/[id]/edit/page.tsx
+++ b/src/app/dashboard/[id]/edit/page.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { apiClient } from '@/api/auth/apiClient';
+import DashboardEditForm from '@/components/DashboardEditForm';
+import MembersSection from '@/components/MembersSection';
+import InvitationsSection from '@/components/InvitationsSection';
+import { GnbDashboard } from '@/components/gnb/Gnb';
+
+interface DashboardInfo {
+  title: string;
+  createdByMe: boolean;
+}
+
+const DashboardEditPage = () => {
+  const params = useParams();
+  const dashboardId = params.id as string;
+  const router = useRouter();
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  // 실제 데이터 state들
+  const [currentUser, setCurrentUser] = useState(null);
+  const [dashboardMembers, setDashboardMembers] = useState([]);
+  const [dashboardInfo, setDashboardInfo] = useState<DashboardInfo | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  // 현재 사용자 정보 가져오기
+  useEffect(() => {
+    const fetchCurrentUser = async () => {
+      try {
+        const response = await apiClient.get('users/me');
+        console.log('현재 사용자 정보:', response.data);
+        setCurrentUser(response.data);
+      } catch (err) {
+        console.error('사용자 정보 조회 실패:', err);
+      }
+    };
+    fetchCurrentUser();
+  }, []);
+
+  // 대시보드 정보 가져오기
+  useEffect(() => {
+    const fetchDashboardInfo = async () => {
+      try {
+        const response = await apiClient.get(`dashboards/${dashboardId}`);
+        console.log('대시보드 정보:', response.data);
+        setDashboardInfo(response.data);
+      } catch (err) {
+        console.error('대시보드 정보 조회 실패:', err);
+      }
+    };
+    fetchDashboardInfo();
+  }, [dashboardId]);
+
+  // 대시보드 구성원 가져오기
+  useEffect(() => {
+    const fetchDashboardMembers = async () => {
+      try {
+        const response = await apiClient.get('members', {
+          params: {
+            dashboardId: dashboardId, // 필수!
+            page: 1, // 선택사항
+            size: 20, // 선택사항
+          },
+        });
+        console.log('대시보드 구성원:', response.data);
+        setDashboardMembers(response.data.members || []);
+      } catch (err) {
+        console.error('구성원 조회 실패:', err);
+        setDashboardMembers([]); // 에러 시 빈 배열
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchDashboardMembers();
+  }, [dashboardId]);
+
+  const handleGoBack = () => {
+    router.push(`/dashboard/${dashboardId}`);
+  };
+
+  const handleDeleteDashboard = async () => {
+    const confirmDelete = confirm(
+      `정말로 이 대시보드를 삭제하시겠습니까?\n\n이 작업은 되돌릴 수 없습니다.`,
+    );
+
+    if (!confirmDelete) return;
+
+    try {
+      setIsDeleting(true);
+      await apiClient.delete(`dashboards/${dashboardId}`);
+      alert('대시보드가 성공적으로 삭제되었습니다.');
+      router.push('/dashboard');
+    } catch (err) {
+      console.error('❌ 대시보드 삭제 실패:', err);
+      alert('대시보드 삭제에 실패했습니다.');
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  // 로딩 중일 때
+  if (loading || !currentUser || !dashboardInfo) {
+    return (
+      <div className='min-h-screen bg-gray-50 flex items-center justify-center'>
+        <div>로딩 중...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className='min-h-screen bg-gray-50'>
+      {/* 상단 Gnb */}
+      <GnbDashboard
+        user={currentUser}
+        users={dashboardMembers}
+        title={dashboardInfo.title}
+        createdByMe={dashboardInfo.createdByMe}
+      />
+
+      <div className='flex'>
+        <div className='flex-1 p-8'>
+          <button
+            onClick={handleGoBack}
+            disabled={isDeleting}
+            className='flex items-center gap-2 text-gray-600 hover:text-gray-800 mb-8 disabled:opacity-50'
+          >
+            <span>←</span>
+            <span>돌아가기</span>
+          </button>
+
+          <div className='mb-8'>
+            <DashboardEditForm dashboardId={dashboardId} />
+          </div>
+
+          <div className='mb-8'>
+            <MembersSection />
+          </div>
+
+          <div className='mb-8'>
+            <InvitationsSection />
+          </div>
+
+          <div>
+            <button
+              onClick={handleDeleteDashboard}
+              disabled={isDeleting}
+              className='px-6 py-3 bg-red-600 text-white rounded-lg hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors'
+            >
+              {isDeleting ? '삭제 중...' : '대시보드 삭제하기'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DashboardEditPage;

--- a/src/components/DashboardEditForm.tsx
+++ b/src/components/DashboardEditForm.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { apiClient } from '@/api/auth/apiClient';
+
+interface DashboardEditFormProps {
+  dashboardId: string;
+}
+
+const DashboardEditForm = ({ dashboardId }: DashboardEditFormProps) => {
+  // 원본 데이터 (큰 제목용)
+  const [originalName, setOriginalName] = useState('');
+
+  // 수정 중인 데이터 (입력폼용)
+  const [dashboardName, setDashboardName] = useState('');
+  const [selectedColor, setSelectedColor] = useState('#7AC555');
+
+  const [loading, setLoading] = useState(true);
+  const [isUpdating, setIsUpdating] = useState(false);
+
+  const colors = [
+    '#7AC555', // 초록
+    '#760DDE', // 보라
+    '#FFA500', // 주황
+    '#76A5EA', // 파랑
+    '#E876EA', // 분홍
+  ];
+
+  // 대시보드 수정하기
+  const handleUpdate = async () => {
+    try {
+      setIsUpdating(true);
+      console.log('대시보드 수정 시도:', { title: dashboardName, color: selectedColor });
+
+      const response = await apiClient.put(`dashboards/${dashboardId}`, {
+        title: dashboardName,
+        color: selectedColor,
+      });
+
+      console.log('✅ 대시보드 수정 성공:', response.data);
+
+      // 성공하면 원본 데이터도 업데이트
+      setOriginalName(dashboardName);
+
+      alert('대시보드가 성공적으로 수정되었습니다!');
+    } catch (err: unknown) {
+      const error = err as { response?: { status?: number; data?: unknown } };
+      console.error('❌ 대시보드 수정 실패:', err);
+      console.error('에러 상세:', error.response?.status, error.response?.data);
+      alert('대시보드 수정에 실패했습니다.');
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
+  useEffect(() => {
+    const fetchDashboard = async () => {
+      try {
+        setLoading(true);
+        const response = await apiClient.get(`dashboards/${dashboardId}`);
+        console.log('대시보드 상세:', response.data);
+
+        // 원본과 수정용 둘 다 설정
+        setOriginalName(response.data.title);
+        setDashboardName(response.data.title);
+        setSelectedColor(response.data.color);
+      } catch (err: unknown) {
+        console.error('대시보드 조회 실패:', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchDashboard();
+  }, [dashboardId]); // dashboardId만 의존성으로
+
+  if (loading) {
+    return <div className='bg-white rounded-lg p-8 shadow-sm'>로딩 중...</div>;
+  }
+
+  return (
+    <div className='bg-white rounded-2xl p-8 shadow-sm max-w-4xl'>
+      {/* 대시보드 이름 (큰 제목) - 원본 데이터 표시 */}
+      <h1 className='text-3xl font-bold text-gray-900 mb-8'>{originalName}</h1>
+
+      {/* 서브 제목 */}
+      <h2 className='text-xl font-semibold text-gray-800 mb-6'>대시보드 이름</h2>
+
+      {/* 이름 입력 - 둥근 모서리, 큰 패딩 */}
+      <div className='mb-8'>
+        <input
+          type='text'
+          value={dashboardName} // 수정 중인 데이터
+          onChange={(e) => setDashboardName(e.target.value)}
+          className='w-full p-4 border-2 border-gray-200 rounded-2xl text-lg focus:border-violet-500 focus:outline-none'
+          placeholder='대시보드 이름을 입력하세요'
+          disabled={isUpdating}
+        />
+      </div>
+
+      {/* 색상 선택 - 크고 체크마크 */}
+      <div className='mb-12'>
+        <div className='flex gap-4'>
+          {colors.map((color) => (
+            <button
+              key={color}
+              onClick={() => setSelectedColor(color)}
+              disabled={isUpdating}
+              className={`w-12 h-12 rounded-full relative ${
+                isUpdating
+                  ? 'opacity-50 cursor-not-allowed'
+                  : 'hover:scale-110 transition-transform'
+              }`}
+              style={{ backgroundColor: color }}
+            >
+              {selectedColor === color && (
+                <div className='absolute inset-0 flex items-center justify-center'>
+                  <svg className='w-10 h-10 text-white' fill='currentColor' viewBox='0 0 20 20'>
+                    <path
+                      fillRule='evenodd'
+                      d='M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z'
+                      clipRule='evenodd'
+                    />
+                  </svg>
+                </div>
+              )}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* 변경 버튼 - 전체 너비, 큰 사이즈 */}
+      <button
+        onClick={handleUpdate}
+        disabled={isUpdating || !dashboardName.trim()}
+        className='w-full py-4 bg-violet-600 text-white text-lg font-semibold rounded-2xl hover:bg-violet-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors'
+      >
+        {isUpdating ? '수정 중...' : '변경'}
+      </button>
+    </div>
+  );
+};
+
+export default DashboardEditForm;

--- a/src/components/InvitationsSection.tsx
+++ b/src/components/InvitationsSection.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { useState } from 'react';
+
+interface Invitation {
+  id: string;
+  email: string;
+}
+
+const InvitationsSection = () => {
+  // 하드코딩된 초대 내역 데이터
+  const [invitations] = useState<Invitation[]>([
+    { id: '1', email: 'codeitA@codeit.com' },
+    { id: '2', email: 'codeitB@codeit.com' },
+    { id: '3', email: 'codeitD@codeit.com' },
+    { id: '4', email: 'codeitC@codeit.com' },
+    { id: '5', email: 'codeitE@codeit.com' },
+  ]);
+
+  const [showInviteModal, setShowInviteModal] = useState(false);
+
+  const handleCancelInvitation = (invitationId: string) => {
+    console.log('취소할 초대 ID:', invitationId);
+    // 나중에 실제 취소 API 연결
+  };
+
+  const handleInvite = () => {
+    setShowInviteModal(true);
+    console.log('초대하기 모달 열기');
+    // 나중에 실제 모달 구현
+  };
+
+  return (
+    <div className='bg-white rounded-lg p-6 shadow-sm'>
+      <div className='flex justify-between items-center mb-6'>
+        <h2 className='text-xl font-bold'>초대 내역</h2>
+        <button
+          onClick={handleInvite}
+          className='px-4 py-2 bg-violet-500 text-white rounded-lg hover:bg-violet-600'
+        >
+          초대하기
+        </button>
+      </div>
+
+      <div className='flex justify-between items-center mb-4'>
+        <span className='text-sm font-medium text-gray-700'>이메일</span>
+        <span className='text-sm text-gray-500'>1 페이지 중 1</span>
+      </div>
+
+      {/* 초대 내역 리스트 */}
+      <div className='space-y-3'>
+        {invitations.map((invitation) => (
+          <div
+            key={invitation.id}
+            className='flex justify-between items-center p-3 border border-gray-200 rounded-lg'
+          >
+            <span className='text-gray-700'>{invitation.email}</span>
+
+            {/* 취소 버튼 */}
+            <button
+              onClick={() => handleCancelInvitation(invitation.id)}
+              className='px-3 py-1 text-sm text-red-600 border border-red-600 rounded hover:bg-red-50'
+            >
+              취소
+            </button>
+          </div>
+        ))}
+      </div>
+
+      {/* 페이지네이션 (임시) */}
+      <div className='flex justify-center mt-6'>
+        <div className='flex gap-2'>
+          <button className='px-3 py-1 border border-gray-300 rounded text-gray-400'>‹</button>
+          <button className='px-3 py-1 bg-violet-500 text-white rounded'>1</button>
+          <button className='px-3 py-1 border border-gray-300 rounded text-gray-400'>›</button>
+        </div>
+      </div>
+
+      {/* 임시 모달 알림 */}
+      {showInviteModal && (
+        <div className='fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50'>
+          <div className='bg-white p-6 rounded-lg'>
+            <h3 className='text-lg font-bold mb-4'>초대하기 모달</h3>
+            <p className='mb-4'>나중에 실제 모달을 만들 예정입니다!</p>
+            <button
+              onClick={() => setShowInviteModal(false)}
+              className='px-4 py-2 bg-gray-500 text-white rounded'
+            >
+              닫기
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default InvitationsSection;

--- a/src/components/MembersSection.tsx
+++ b/src/components/MembersSection.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useState } from 'react';
+
+interface Member {
+  id: string;
+  name: string;
+  profileImage?: string;
+}
+
+const MembersSection = () => {
+  // 하드코딩된 구성원 데이터
+  const [members] = useState<Member[]>([
+    { id: '1', name: '정만철' },
+    { id: '2', name: '최주협' },
+    { id: '3', name: '김태순' },
+    { id: '4', name: '윤지현' },
+  ]);
+
+  const handleDeleteMember = (memberId: string) => {
+    console.log('삭제할 구성원 ID:', memberId);
+    // 나중에 실제 삭제 API 연결
+  };
+
+  return (
+    <div className="bg-white rounded-lg p-6 shadow-sm">
+      <div className="flex justify-between items-center mb-6">
+        <h2 className="text-xl font-bold">구성원</h2>
+        <span className="text-sm text-gray-500">1 페이지 중 1</span>
+      </div>
+
+      {/* 구성원 리스트 */}
+      <div className="space-y-4">
+        {members.map((member) => (
+          <div key={member.id} className="flex justify-between items-center p-3 border border-gray-200 rounded-lg">
+            <div className="flex items-center gap-3">
+              {/* 프로필 아이콘 */}
+              <div className="w-8 h-8 bg-gray-300 rounded-full flex items-center justify-center text-white font-medium">
+                {member.name[0]}
+              </div>
+              <span className="font-medium">{member.name}</span>
+            </div>
+            
+            {/* 삭제 버튼 */}
+            <button
+              onClick={() => handleDeleteMember(member.id)}
+              className="px-3 py-1 text-sm text-red-600 border border-red-600 rounded hover:bg-red-50"
+            >
+              삭제
+            </button>
+          </div>
+        ))}
+      </div>
+
+      {/* 페이지네이션 (임시) */}
+      <div className="flex justify-center mt-6">
+        <div className="flex gap-2">
+          <button className="px-3 py-1 border border-gray-300 rounded text-gray-400">‹</button>
+          <button className="px-3 py-1 bg-violet-500 text-white rounded">1</button>
+          <button className="px-3 py-1 border border-gray-300 rounded text-gray-400">›</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MembersSection;


### PR DESCRIPTION
## ✨ 작업 내용

<!-- 어떤 작업을 했는지 간단히 작성해주세요 -->

1. 대시보드 수정 폼 (이름, 색상 변경) - API 연결 완료
2. 대시보드 삭제 기능 - API 연결 완료

- 멤버 관리 섹션 UI 구현 (하드코딩 데이터)
- 초대 관리 섹션 UI 구현 (하드코딩 데이터)

<img width="1920" height="1742" alt="screencapture-localhost-3000-dashboard-15540-edit-2025-07-26-15_45_48" src="https://github.com/user-attachments/assets/923de135-373b-41f6-8dd8-c57a98fa8067" />
